### PR TITLE
Add AutoComplete and Amiibo sort

### DIFF
--- a/emutool/emutool/AmiiboAPI.cs
+++ b/emutool/emutool/AmiiboAPI.cs
@@ -40,7 +40,7 @@ namespace emutool
                 var list = new List<Amiibo>();
                 if(Amiibos.Any())
                 {
-                    list.AddRange(Amiibos.Where(amiibo => amiibo.SeriesName == series));
+                    list.AddRange(Amiibos.Where(amiibo => amiibo.SeriesName == series).OrderBy(amiibo => amiibo.AmiiboName));
                 }
                 return list;
             }

--- a/emutool/emutool/MainForm.Designer.cs
+++ b/emutool/emutool/MainForm.Designer.cs
@@ -351,6 +351,8 @@
 			// 
 			// AmiiboComboBox
 			// 
+			this.AmiiboComboBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
+			this.AmiiboComboBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
 			this.AmiiboComboBox.FormattingEnabled = true;
 			this.AmiiboComboBox.Location = new System.Drawing.Point(202, 29);
 			this.AmiiboComboBox.Name = "AmiiboComboBox";

--- a/emutool/emutool/MainForm.Designer.cs
+++ b/emutool/emutool/MainForm.Designer.cs
@@ -28,388 +28,387 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
-            this.AmiiboNameBox = new System.Windows.Forms.TextBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.RandomizeUuidCheck = new System.Windows.Forms.CheckBox();
-            this.label2 = new System.Windows.Forms.Label();
-            this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.CreateAllCheck = new System.Windows.Forms.CheckBox();
-            this.UseNameCheck = new System.Windows.Forms.CheckBox();
-            this.DirectoryNameBox = new System.Windows.Forms.TextBox();
-            this.label8 = new System.Windows.Forms.Label();
-            this.label9 = new System.Windows.Forms.Label();
-            this.FtpPortBox = new System.Windows.Forms.TextBox();
-            this.label5 = new System.Windows.Forms.Label();
-            this.SaveImageCheck = new System.Windows.Forms.CheckBox();
-            this.FtpAddressBox = new System.Windows.Forms.TextBox();
-            this.label6 = new System.Windows.Forms.Label();
-            this.FtpSaveCheck = new System.Windows.Forms.CheckBox();
-            this.CreateButton = new System.Windows.Forms.Button();
-            this.label3 = new System.Windows.Forms.Label();
-            this.groupBox3 = new System.Windows.Forms.GroupBox();
-            this.LastPathCheck = new System.Windows.Forms.CheckBox();
-            this.LastPathLabel = new System.Windows.Forms.Label();
-            this.label7 = new System.Windows.Forms.Label();
-            this.statusStrip1 = new System.Windows.Forms.StatusStrip();
-            this.toolStripStatusLabel2 = new System.Windows.Forms.ToolStripStatusLabel();
-            this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
-            this.AmiiboPictureBox = new System.Windows.Forms.PictureBox();
-            this.SeriesComboBox = new System.Windows.Forms.ComboBox();
-            this.AmiiboComboBox = new System.Windows.Forms.ComboBox();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.AboutButton = new System.Windows.Forms.Button();
-            this.groupBox2.SuspendLayout();
-            this.groupBox3.SuspendLayout();
-            this.statusStrip1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.AmiiboPictureBox)).BeginInit();
-            this.groupBox1.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // AmiiboNameBox
-            // 
-            this.AmiiboNameBox.Location = new System.Drawing.Point(124, 25);
-            this.AmiiboNameBox.MaxLength = 10;
-            this.AmiiboNameBox.Name = "AmiiboNameBox";
-            this.AmiiboNameBox.Size = new System.Drawing.Size(255, 20);
-            this.AmiiboNameBox.TabIndex = 1;
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(15, 28);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(43, 13);
-            this.label1.TabIndex = 2;
-            this.label1.Text = "Name:";
-            // 
-            // RandomizeUuidCheck
-            // 
-            this.RandomizeUuidCheck.AutoSize = true;
-            this.RandomizeUuidCheck.Location = new System.Drawing.Point(18, 202);
-            this.RandomizeUuidCheck.Name = "RandomizeUuidCheck";
-            this.RandomizeUuidCheck.Size = new System.Drawing.Size(168, 17);
-            this.RandomizeUuidCheck.TabIndex = 4;
-            this.RandomizeUuidCheck.Text = "Randomize UUID in emulation";
-            this.RandomizeUuidCheck.UseVisualStyleBackColor = true;
-            this.RandomizeUuidCheck.CheckedChanged += new System.EventHandler(this.CheckBox1_CheckedChanged);
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(15, 125);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(361, 65);
-            this.label2.TabIndex = 5;
-            this.label2.Text = resources.GetString("label2.Text");
-            // 
-            // groupBox2
-            // 
-            this.groupBox2.Controls.Add(this.UseNameCheck);
-            this.groupBox2.Controls.Add(this.DirectoryNameBox);
-            this.groupBox2.Controls.Add(this.label8);
-            this.groupBox2.Controls.Add(this.label9);
-            this.groupBox2.Controls.Add(this.FtpPortBox);
-            this.groupBox2.Controls.Add(this.label5);
-            this.groupBox2.Controls.Add(this.SaveImageCheck);
-            this.groupBox2.Controls.Add(this.label1);
-            this.groupBox2.Controls.Add(this.FtpAddressBox);
-            this.groupBox2.Controls.Add(this.label2);
-            this.groupBox2.Controls.Add(this.label6);
-            this.groupBox2.Controls.Add(this.AmiiboNameBox);
-            this.groupBox2.Controls.Add(this.FtpSaveCheck);
-            this.groupBox2.Controls.Add(this.RandomizeUuidCheck);
-            this.groupBox2.Location = new System.Drawing.Point(418, 12);
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(396, 341);
-            this.groupBox2.TabIndex = 6;
-            this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "2 - Generation settings";
-            // 
-            // CreateAllCheck
-            // 
-            this.CreateAllCheck.AutoSize = true;
-            this.CreateAllCheck.Location = new System.Drawing.Point(51, 514);
-            this.CreateAllCheck.Name = "CreateAllCheck";
-            this.CreateAllCheck.Size = new System.Drawing.Size(294, 17);
-            this.CreateAllCheck.TabIndex = 11;
-            this.CreateAllCheck.Text = "Generate all amiibos at once, instead of the selected one";
-            this.CreateAllCheck.UseVisualStyleBackColor = true;
-            this.CreateAllCheck.CheckedChanged += new System.EventHandler(this.generateAllAmibosCheck_CheckedChanged);
-            // 
-            // UseNameCheck
-            // 
-            this.UseNameCheck.AutoSize = true;
-            this.UseNameCheck.Checked = true;
-            this.UseNameCheck.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.UseNameCheck.Location = new System.Drawing.Point(124, 77);
-            this.UseNameCheck.Name = "UseNameCheck";
-            this.UseNameCheck.Size = new System.Drawing.Size(160, 17);
-            this.UseNameCheck.TabIndex = 10;
-            this.UseNameCheck.Text = "Use name as directory name";
-            this.UseNameCheck.UseVisualStyleBackColor = true;
-            this.UseNameCheck.CheckedChanged += new System.EventHandler(this.CheckBox3_CheckedChanged);
-            // 
-            // DirectoryNameBox
-            // 
-            this.DirectoryNameBox.Enabled = false;
-            this.DirectoryNameBox.Location = new System.Drawing.Point(124, 51);
-            this.DirectoryNameBox.MaxLength = 10;
-            this.DirectoryNameBox.Name = "DirectoryNameBox";
-            this.DirectoryNameBox.Size = new System.Drawing.Size(255, 20);
-            this.DirectoryNameBox.TabIndex = 9;
-            // 
-            // label8
-            // 
-            this.label8.AutoSize = true;
-            this.label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label8.Location = new System.Drawing.Point(229, 294);
-            this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(34, 13);
-            this.label8.TabIndex = 13;
-            this.label8.Text = "Port:";
-            // 
-            // label9
-            // 
-            this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(15, 313);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(32, 13);
-            this.label9.TabIndex = 11;
-            this.label9.Text = "ftp://";
-            // 
-            // FtpPortBox
-            // 
-            this.FtpPortBox.Enabled = false;
-            this.FtpPortBox.Location = new System.Drawing.Point(230, 310);
-            this.FtpPortBox.Name = "FtpPortBox";
-            this.FtpPortBox.Size = new System.Drawing.Size(149, 20);
-            this.FtpPortBox.TabIndex = 14;
-            // 
-            // label5
-            // 
-            this.label5.AutoSize = true;
-            this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label5.Location = new System.Drawing.Point(15, 54);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(96, 13);
-            this.label5.TabIndex = 8;
-            this.label5.Text = "Directory name:";
-            // 
-            // SaveImageCheck
-            // 
-            this.SaveImageCheck.AutoSize = true;
-            this.SaveImageCheck.Location = new System.Drawing.Point(18, 247);
-            this.SaveImageCheck.Name = "SaveImageCheck";
-            this.SaveImageCheck.Size = new System.Drawing.Size(245, 17);
-            this.SaveImageCheck.TabIndex = 7;
-            this.SaveImageCheck.Text = "Save the amiibo\'s image along with the amiibo.";
-            this.SaveImageCheck.UseVisualStyleBackColor = true;
-            // 
-            // FtpAddressBox
-            // 
-            this.FtpAddressBox.Enabled = false;
-            this.FtpAddressBox.Location = new System.Drawing.Point(53, 310);
-            this.FtpAddressBox.Name = "FtpAddressBox";
-            this.FtpAddressBox.Size = new System.Drawing.Size(149, 20);
-            this.FtpAddressBox.TabIndex = 12;
-            // 
-            // label6
-            // 
-            this.label6.AutoSize = true;
-            this.label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label6.Location = new System.Drawing.Point(55, 294);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(56, 13);
-            this.label6.TabIndex = 11;
-            this.label6.Text = "Address:";
-            // 
-            // FtpSaveCheck
-            // 
-            this.FtpSaveCheck.AutoSize = true;
-            this.FtpSaveCheck.Location = new System.Drawing.Point(18, 270);
-            this.FtpSaveCheck.Name = "FtpSaveCheck";
-            this.FtpSaveCheck.Size = new System.Drawing.Size(184, 17);
-            this.FtpSaveCheck.TabIndex = 11;
-            this.FtpSaveCheck.Text = "Upload generated amiibos to FTP";
-            this.FtpSaveCheck.UseVisualStyleBackColor = true;
-            this.FtpSaveCheck.CheckedChanged += new System.EventHandler(this.chkFTP_CheckedChanged);
-            // 
-            // CreateButton
-            // 
-            this.CreateButton.Location = new System.Drawing.Point(15, 61);
-            this.CreateButton.Name = "CreateButton";
-            this.CreateButton.Size = new System.Drawing.Size(361, 34);
-            this.CreateButton.TabIndex = 7;
-            this.CreateButton.Text = "Create virtual amiibo";
-            this.CreateButton.UseVisualStyleBackColor = true;
-            this.CreateButton.Click += new System.EventHandler(this.Button1_Click);
-            // 
-            // label3
-            // 
-            this.label3.AutoSize = true;
-            this.label3.BackColor = System.Drawing.SystemColors.Control;
-            this.label3.ForeColor = System.Drawing.Color.DimGray;
-            this.label3.Location = new System.Drawing.Point(473, 530);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(291, 13);
-            this.label3.TabIndex = 8;
-            this.label3.Text = "In console, emuiibo will generate a random mii for the amiibo.";
-            // 
-            // groupBox3
-            // 
-            this.groupBox3.Controls.Add(this.LastPathCheck);
-            this.groupBox3.Controls.Add(this.LastPathLabel);
-            this.groupBox3.Controls.Add(this.label7);
-            this.groupBox3.Controls.Add(this.CreateButton);
-            this.groupBox3.Location = new System.Drawing.Point(418, 358);
-            this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(396, 112);
-            this.groupBox3.TabIndex = 9;
-            this.groupBox3.TabStop = false;
-            this.groupBox3.Text = "3 - Generate the virtual amiibo";
-            // 
-            // LastPathCheck
-            // 
-            this.LastPathCheck.AutoSize = true;
-            this.LastPathCheck.Checked = true;
-            this.LastPathCheck.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.LastPathCheck.Location = new System.Drawing.Point(15, 34);
-            this.LastPathCheck.Name = "LastPathCheck";
-            this.LastPathCheck.Size = new System.Drawing.Size(155, 17);
-            this.LastPathCheck.TabIndex = 17;
-            this.LastPathCheck.Text = "Create in the last used path\n";
-            this.LastPathCheck.UseVisualStyleBackColor = true;
-            this.LastPathCheck.Visible = false;
-            // 
-            // LastPathLabel
-            // 
-            this.LastPathLabel.AutoSize = true;
-            this.LastPathLabel.BackColor = System.Drawing.SystemColors.Control;
-            this.LastPathLabel.ForeColor = System.Drawing.Color.DimGray;
-            this.LastPathLabel.Location = new System.Drawing.Point(12, 18);
-            this.LastPathLabel.Name = "LastPathLabel";
-            this.LastPathLabel.Size = new System.Drawing.Size(42, 13);
-            this.LastPathLabel.TabIndex = 16;
-            this.LastPathLabel.Text = "Dummy";
-            this.LastPathLabel.Visible = false;
-            // 
-            // label7
-            // 
-            this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(12, 92);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(0, 13);
-            this.label7.TabIndex = 11;
-            // 
-            // statusStrip1
-            // 
-            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
+			this.AmiiboNameBox = new System.Windows.Forms.TextBox();
+			this.label1 = new System.Windows.Forms.Label();
+			this.RandomizeUuidCheck = new System.Windows.Forms.CheckBox();
+			this.label2 = new System.Windows.Forms.Label();
+			this.groupBox2 = new System.Windows.Forms.GroupBox();
+			this.UseNameCheck = new System.Windows.Forms.CheckBox();
+			this.DirectoryNameBox = new System.Windows.Forms.TextBox();
+			this.label8 = new System.Windows.Forms.Label();
+			this.label9 = new System.Windows.Forms.Label();
+			this.FtpPortBox = new System.Windows.Forms.TextBox();
+			this.label5 = new System.Windows.Forms.Label();
+			this.SaveImageCheck = new System.Windows.Forms.CheckBox();
+			this.FtpAddressBox = new System.Windows.Forms.TextBox();
+			this.label6 = new System.Windows.Forms.Label();
+			this.FtpSaveCheck = new System.Windows.Forms.CheckBox();
+			this.CreateAllCheck = new System.Windows.Forms.CheckBox();
+			this.CreateButton = new System.Windows.Forms.Button();
+			this.label3 = new System.Windows.Forms.Label();
+			this.groupBox3 = new System.Windows.Forms.GroupBox();
+			this.LastPathCheck = new System.Windows.Forms.CheckBox();
+			this.LastPathLabel = new System.Windows.Forms.Label();
+			this.label7 = new System.Windows.Forms.Label();
+			this.statusStrip1 = new System.Windows.Forms.StatusStrip();
+			this.toolStripStatusLabel2 = new System.Windows.Forms.ToolStripStatusLabel();
+			this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
+			this.AmiiboPictureBox = new System.Windows.Forms.PictureBox();
+			this.SeriesComboBox = new System.Windows.Forms.ComboBox();
+			this.AmiiboComboBox = new System.Windows.Forms.ComboBox();
+			this.groupBox1 = new System.Windows.Forms.GroupBox();
+			this.AboutButton = new System.Windows.Forms.Button();
+			this.groupBox2.SuspendLayout();
+			this.groupBox3.SuspendLayout();
+			this.statusStrip1.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.AmiiboPictureBox)).BeginInit();
+			this.groupBox1.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// AmiiboNameBox
+			// 
+			this.AmiiboNameBox.Location = new System.Drawing.Point(124, 25);
+			this.AmiiboNameBox.MaxLength = 10;
+			this.AmiiboNameBox.Name = "AmiiboNameBox";
+			this.AmiiboNameBox.Size = new System.Drawing.Size(255, 20);
+			this.AmiiboNameBox.TabIndex = 1;
+			// 
+			// label1
+			// 
+			this.label1.AutoSize = true;
+			this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label1.Location = new System.Drawing.Point(15, 28);
+			this.label1.Name = "label1";
+			this.label1.Size = new System.Drawing.Size(43, 13);
+			this.label1.TabIndex = 2;
+			this.label1.Text = "Name:";
+			// 
+			// RandomizeUuidCheck
+			// 
+			this.RandomizeUuidCheck.AutoSize = true;
+			this.RandomizeUuidCheck.Location = new System.Drawing.Point(18, 202);
+			this.RandomizeUuidCheck.Name = "RandomizeUuidCheck";
+			this.RandomizeUuidCheck.Size = new System.Drawing.Size(168, 17);
+			this.RandomizeUuidCheck.TabIndex = 4;
+			this.RandomizeUuidCheck.Text = "Randomize UUID in emulation";
+			this.RandomizeUuidCheck.UseVisualStyleBackColor = true;
+			this.RandomizeUuidCheck.CheckedChanged += new System.EventHandler(this.CheckBox1_CheckedChanged);
+			// 
+			// label2
+			// 
+			this.label2.AutoSize = true;
+			this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label2.Location = new System.Drawing.Point(15, 125);
+			this.label2.Name = "label2";
+			this.label2.Size = new System.Drawing.Size(361, 65);
+			this.label2.TabIndex = 5;
+			this.label2.Text = resources.GetString("label2.Text");
+			// 
+			// groupBox2
+			// 
+			this.groupBox2.Controls.Add(this.UseNameCheck);
+			this.groupBox2.Controls.Add(this.DirectoryNameBox);
+			this.groupBox2.Controls.Add(this.label8);
+			this.groupBox2.Controls.Add(this.label9);
+			this.groupBox2.Controls.Add(this.FtpPortBox);
+			this.groupBox2.Controls.Add(this.label5);
+			this.groupBox2.Controls.Add(this.SaveImageCheck);
+			this.groupBox2.Controls.Add(this.label1);
+			this.groupBox2.Controls.Add(this.FtpAddressBox);
+			this.groupBox2.Controls.Add(this.label2);
+			this.groupBox2.Controls.Add(this.label6);
+			this.groupBox2.Controls.Add(this.AmiiboNameBox);
+			this.groupBox2.Controls.Add(this.FtpSaveCheck);
+			this.groupBox2.Controls.Add(this.RandomizeUuidCheck);
+			this.groupBox2.Location = new System.Drawing.Point(418, 12);
+			this.groupBox2.Name = "groupBox2";
+			this.groupBox2.Size = new System.Drawing.Size(396, 341);
+			this.groupBox2.TabIndex = 6;
+			this.groupBox2.TabStop = false;
+			this.groupBox2.Text = "2 - Generation settings";
+			// 
+			// UseNameCheck
+			// 
+			this.UseNameCheck.AutoSize = true;
+			this.UseNameCheck.Checked = true;
+			this.UseNameCheck.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.UseNameCheck.Location = new System.Drawing.Point(124, 77);
+			this.UseNameCheck.Name = "UseNameCheck";
+			this.UseNameCheck.Size = new System.Drawing.Size(160, 17);
+			this.UseNameCheck.TabIndex = 10;
+			this.UseNameCheck.Text = "Use name as directory name";
+			this.UseNameCheck.UseVisualStyleBackColor = true;
+			this.UseNameCheck.CheckedChanged += new System.EventHandler(this.CheckBox3_CheckedChanged);
+			// 
+			// DirectoryNameBox
+			// 
+			this.DirectoryNameBox.Enabled = false;
+			this.DirectoryNameBox.Location = new System.Drawing.Point(124, 51);
+			this.DirectoryNameBox.MaxLength = 10;
+			this.DirectoryNameBox.Name = "DirectoryNameBox";
+			this.DirectoryNameBox.Size = new System.Drawing.Size(255, 20);
+			this.DirectoryNameBox.TabIndex = 9;
+			// 
+			// label8
+			// 
+			this.label8.AutoSize = true;
+			this.label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label8.Location = new System.Drawing.Point(229, 294);
+			this.label8.Name = "label8";
+			this.label8.Size = new System.Drawing.Size(34, 13);
+			this.label8.TabIndex = 13;
+			this.label8.Text = "Port:";
+			// 
+			// label9
+			// 
+			this.label9.AutoSize = true;
+			this.label9.Location = new System.Drawing.Point(15, 313);
+			this.label9.Name = "label9";
+			this.label9.Size = new System.Drawing.Size(32, 13);
+			this.label9.TabIndex = 11;
+			this.label9.Text = "ftp://";
+			// 
+			// FtpPortBox
+			// 
+			this.FtpPortBox.Enabled = false;
+			this.FtpPortBox.Location = new System.Drawing.Point(230, 310);
+			this.FtpPortBox.Name = "FtpPortBox";
+			this.FtpPortBox.Size = new System.Drawing.Size(149, 20);
+			this.FtpPortBox.TabIndex = 14;
+			// 
+			// label5
+			// 
+			this.label5.AutoSize = true;
+			this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label5.Location = new System.Drawing.Point(15, 54);
+			this.label5.Name = "label5";
+			this.label5.Size = new System.Drawing.Size(96, 13);
+			this.label5.TabIndex = 8;
+			this.label5.Text = "Directory name:";
+			// 
+			// SaveImageCheck
+			// 
+			this.SaveImageCheck.AutoSize = true;
+			this.SaveImageCheck.Location = new System.Drawing.Point(18, 247);
+			this.SaveImageCheck.Name = "SaveImageCheck";
+			this.SaveImageCheck.Size = new System.Drawing.Size(245, 17);
+			this.SaveImageCheck.TabIndex = 7;
+			this.SaveImageCheck.Text = "Save the amiibo\'s image along with the amiibo.";
+			this.SaveImageCheck.UseVisualStyleBackColor = true;
+			// 
+			// FtpAddressBox
+			// 
+			this.FtpAddressBox.Enabled = false;
+			this.FtpAddressBox.Location = new System.Drawing.Point(53, 310);
+			this.FtpAddressBox.Name = "FtpAddressBox";
+			this.FtpAddressBox.Size = new System.Drawing.Size(149, 20);
+			this.FtpAddressBox.TabIndex = 12;
+			// 
+			// label6
+			// 
+			this.label6.AutoSize = true;
+			this.label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label6.Location = new System.Drawing.Point(55, 294);
+			this.label6.Name = "label6";
+			this.label6.Size = new System.Drawing.Size(56, 13);
+			this.label6.TabIndex = 11;
+			this.label6.Text = "Address:";
+			// 
+			// FtpSaveCheck
+			// 
+			this.FtpSaveCheck.AutoSize = true;
+			this.FtpSaveCheck.Location = new System.Drawing.Point(18, 270);
+			this.FtpSaveCheck.Name = "FtpSaveCheck";
+			this.FtpSaveCheck.Size = new System.Drawing.Size(184, 17);
+			this.FtpSaveCheck.TabIndex = 11;
+			this.FtpSaveCheck.Text = "Upload generated amiibos to FTP";
+			this.FtpSaveCheck.UseVisualStyleBackColor = true;
+			this.FtpSaveCheck.CheckedChanged += new System.EventHandler(this.chkFTP_CheckedChanged);
+			// 
+			// CreateAllCheck
+			// 
+			this.CreateAllCheck.AutoSize = true;
+			this.CreateAllCheck.Location = new System.Drawing.Point(51, 514);
+			this.CreateAllCheck.Name = "CreateAllCheck";
+			this.CreateAllCheck.Size = new System.Drawing.Size(294, 17);
+			this.CreateAllCheck.TabIndex = 11;
+			this.CreateAllCheck.Text = "Generate all amiibos at once, instead of the selected one";
+			this.CreateAllCheck.UseVisualStyleBackColor = true;
+			this.CreateAllCheck.CheckedChanged += new System.EventHandler(this.generateAllAmibosCheck_CheckedChanged);
+			// 
+			// CreateButton
+			// 
+			this.CreateButton.Location = new System.Drawing.Point(15, 61);
+			this.CreateButton.Name = "CreateButton";
+			this.CreateButton.Size = new System.Drawing.Size(361, 34);
+			this.CreateButton.TabIndex = 7;
+			this.CreateButton.Text = "Create virtual amiibo";
+			this.CreateButton.UseVisualStyleBackColor = true;
+			this.CreateButton.Click += new System.EventHandler(this.Button1_Click);
+			// 
+			// label3
+			// 
+			this.label3.AutoSize = true;
+			this.label3.BackColor = System.Drawing.SystemColors.Control;
+			this.label3.ForeColor = System.Drawing.Color.DimGray;
+			this.label3.Location = new System.Drawing.Point(473, 530);
+			this.label3.Name = "label3";
+			this.label3.Size = new System.Drawing.Size(291, 13);
+			this.label3.TabIndex = 8;
+			this.label3.Text = "In console, emuiibo will generate a random mii for the amiibo.";
+			// 
+			// groupBox3
+			// 
+			this.groupBox3.Controls.Add(this.LastPathCheck);
+			this.groupBox3.Controls.Add(this.LastPathLabel);
+			this.groupBox3.Controls.Add(this.label7);
+			this.groupBox3.Controls.Add(this.CreateButton);
+			this.groupBox3.Location = new System.Drawing.Point(418, 358);
+			this.groupBox3.Name = "groupBox3";
+			this.groupBox3.Size = new System.Drawing.Size(396, 112);
+			this.groupBox3.TabIndex = 9;
+			this.groupBox3.TabStop = false;
+			this.groupBox3.Text = "3 - Generate the virtual amiibo";
+			// 
+			// LastPathCheck
+			// 
+			this.LastPathCheck.AutoSize = true;
+			this.LastPathCheck.Checked = true;
+			this.LastPathCheck.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.LastPathCheck.Location = new System.Drawing.Point(15, 34);
+			this.LastPathCheck.Name = "LastPathCheck";
+			this.LastPathCheck.Size = new System.Drawing.Size(155, 17);
+			this.LastPathCheck.TabIndex = 17;
+			this.LastPathCheck.Text = "Create in the last used path\n";
+			this.LastPathCheck.UseVisualStyleBackColor = true;
+			this.LastPathCheck.Visible = false;
+			// 
+			// LastPathLabel
+			// 
+			this.LastPathLabel.AutoSize = true;
+			this.LastPathLabel.BackColor = System.Drawing.SystemColors.Control;
+			this.LastPathLabel.ForeColor = System.Drawing.Color.DimGray;
+			this.LastPathLabel.Location = new System.Drawing.Point(12, 18);
+			this.LastPathLabel.Name = "LastPathLabel";
+			this.LastPathLabel.Size = new System.Drawing.Size(42, 13);
+			this.LastPathLabel.TabIndex = 16;
+			this.LastPathLabel.Text = "Dummy";
+			this.LastPathLabel.Visible = false;
+			// 
+			// label7
+			// 
+			this.label7.AutoSize = true;
+			this.label7.Location = new System.Drawing.Point(12, 92);
+			this.label7.Name = "label7";
+			this.label7.Size = new System.Drawing.Size(0, 13);
+			this.label7.TabIndex = 11;
+			// 
+			// statusStrip1
+			// 
+			this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripStatusLabel2,
             this.toolStripStatusLabel1});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 567);
-            this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Size = new System.Drawing.Size(826, 22);
-            this.statusStrip1.SizingGrip = false;
-            this.statusStrip1.TabIndex = 10;
-            this.statusStrip1.Text = "statusStrip1";
-            // 
-            // toolStripStatusLabel2
-            // 
-            this.toolStripStatusLabel2.Name = "toolStripStatusLabel2";
-            this.toolStripStatusLabel2.Size = new System.Drawing.Size(776, 17);
-            this.toolStripStatusLabel2.Spring = true;
-            // 
-            // toolStripStatusLabel1
-            // 
-            this.toolStripStatusLabel1.Image = global::emutool.Properties.Resources.OkIcon;
-            this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
-            this.toolStripStatusLabel1.Size = new System.Drawing.Size(35, 17);
-            this.toolStripStatusLabel1.Text = "    ";
-            this.toolStripStatusLabel1.TextImageRelation = System.Windows.Forms.TextImageRelation.TextBeforeImage;
-            // 
-            // AmiiboPictureBox
-            // 
-            this.AmiiboPictureBox.Location = new System.Drawing.Point(17, 63);
-            this.AmiiboPictureBox.Name = "AmiiboPictureBox";
-            this.AmiiboPictureBox.Size = new System.Drawing.Size(362, 434);
-            this.AmiiboPictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            this.AmiiboPictureBox.TabIndex = 0;
-            this.AmiiboPictureBox.TabStop = false;
-            // 
-            // SeriesComboBox
-            // 
-            this.SeriesComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.SeriesComboBox.FormattingEnabled = true;
-            this.SeriesComboBox.Location = new System.Drawing.Point(17, 29);
-            this.SeriesComboBox.Name = "SeriesComboBox";
-            this.SeriesComboBox.Size = new System.Drawing.Size(177, 21);
-            this.SeriesComboBox.TabIndex = 1;
-            this.SeriesComboBox.SelectedIndexChanged += new System.EventHandler(this.ComboBox1_SelectedIndexChanged);
-            // 
-            // AmiiboComboBox
-            // 
-            this.AmiiboComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.AmiiboComboBox.FormattingEnabled = true;
-            this.AmiiboComboBox.Location = new System.Drawing.Point(202, 29);
-            this.AmiiboComboBox.Name = "AmiiboComboBox";
-            this.AmiiboComboBox.Size = new System.Drawing.Size(177, 21);
-            this.AmiiboComboBox.TabIndex = 2;
-            this.AmiiboComboBox.SelectedIndexChanged += new System.EventHandler(this.comboBox2_SelectedIndexChanged);
-            // 
-            // groupBox1
-            // 
-            this.groupBox1.Controls.Add(this.CreateAllCheck);
-            this.groupBox1.Controls.Add(this.AmiiboComboBox);
-            this.groupBox1.Controls.Add(this.SeriesComboBox);
-            this.groupBox1.Controls.Add(this.AmiiboPictureBox);
-            this.groupBox1.Location = new System.Drawing.Point(12, 12);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(396, 547);
-            this.groupBox1.TabIndex = 3;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "1 - Choose a virtual amiibo";
-            // 
-            // AboutButton
-            // 
-            this.AboutButton.Location = new System.Drawing.Point(437, 494);
-            this.AboutButton.Name = "AboutButton";
-            this.AboutButton.Size = new System.Drawing.Size(362, 28);
-            this.AboutButton.TabIndex = 12;
-            this.AboutButton.Text = "About emuiibo and emutool";
-            this.AboutButton.UseVisualStyleBackColor = true;
-            this.AboutButton.Click += new System.EventHandler(this.AboutButton_Click);
-            // 
-            // MainForm
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(826, 589);
-            this.Controls.Add(this.AboutButton);
-            this.Controls.Add(this.statusStrip1);
-            this.Controls.Add(this.groupBox3);
-            this.Controls.Add(this.groupBox2);
-            this.Controls.Add(this.groupBox1);
-            this.Controls.Add(this.label3);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MaximizeBox = false;
-            this.Name = "MainForm";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Dummy";
-            this.groupBox2.ResumeLayout(false);
-            this.groupBox2.PerformLayout();
-            this.groupBox3.ResumeLayout(false);
-            this.groupBox3.PerformLayout();
-            this.statusStrip1.ResumeLayout(false);
-            this.statusStrip1.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.AmiiboPictureBox)).EndInit();
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
+			this.statusStrip1.Location = new System.Drawing.Point(0, 567);
+			this.statusStrip1.Name = "statusStrip1";
+			this.statusStrip1.Size = new System.Drawing.Size(826, 22);
+			this.statusStrip1.SizingGrip = false;
+			this.statusStrip1.TabIndex = 10;
+			this.statusStrip1.Text = "statusStrip1";
+			// 
+			// toolStripStatusLabel2
+			// 
+			this.toolStripStatusLabel2.Name = "toolStripStatusLabel2";
+			this.toolStripStatusLabel2.Size = new System.Drawing.Size(776, 17);
+			this.toolStripStatusLabel2.Spring = true;
+			// 
+			// toolStripStatusLabel1
+			// 
+			this.toolStripStatusLabel1.Image = global::emutool.Properties.Resources.OkIcon;
+			this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
+			this.toolStripStatusLabel1.Size = new System.Drawing.Size(35, 17);
+			this.toolStripStatusLabel1.Text = "    ";
+			this.toolStripStatusLabel1.TextImageRelation = System.Windows.Forms.TextImageRelation.TextBeforeImage;
+			// 
+			// AmiiboPictureBox
+			// 
+			this.AmiiboPictureBox.Location = new System.Drawing.Point(17, 63);
+			this.AmiiboPictureBox.Name = "AmiiboPictureBox";
+			this.AmiiboPictureBox.Size = new System.Drawing.Size(362, 434);
+			this.AmiiboPictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+			this.AmiiboPictureBox.TabIndex = 0;
+			this.AmiiboPictureBox.TabStop = false;
+			// 
+			// SeriesComboBox
+			// 
+			this.SeriesComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.SeriesComboBox.FormattingEnabled = true;
+			this.SeriesComboBox.Location = new System.Drawing.Point(17, 29);
+			this.SeriesComboBox.Name = "SeriesComboBox";
+			this.SeriesComboBox.Size = new System.Drawing.Size(177, 21);
+			this.SeriesComboBox.TabIndex = 1;
+			this.SeriesComboBox.SelectedIndexChanged += new System.EventHandler(this.SeriesComboBox_SelectedIndexChanged);
+			// 
+			// AmiiboComboBox
+			// 
+			this.AmiiboComboBox.FormattingEnabled = true;
+			this.AmiiboComboBox.Location = new System.Drawing.Point(202, 29);
+			this.AmiiboComboBox.Name = "AmiiboComboBox";
+			this.AmiiboComboBox.Size = new System.Drawing.Size(177, 21);
+			this.AmiiboComboBox.TabIndex = 2;
+			this.AmiiboComboBox.SelectedIndexChanged += new System.EventHandler(this.AmiiboComboBox_SelectedIndexChanged);
+			// 
+			// groupBox1
+			// 
+			this.groupBox1.Controls.Add(this.CreateAllCheck);
+			this.groupBox1.Controls.Add(this.AmiiboComboBox);
+			this.groupBox1.Controls.Add(this.SeriesComboBox);
+			this.groupBox1.Controls.Add(this.AmiiboPictureBox);
+			this.groupBox1.Location = new System.Drawing.Point(12, 12);
+			this.groupBox1.Name = "groupBox1";
+			this.groupBox1.Size = new System.Drawing.Size(396, 547);
+			this.groupBox1.TabIndex = 3;
+			this.groupBox1.TabStop = false;
+			this.groupBox1.Text = "1 - Choose a virtual amiibo";
+			// 
+			// AboutButton
+			// 
+			this.AboutButton.Location = new System.Drawing.Point(437, 494);
+			this.AboutButton.Name = "AboutButton";
+			this.AboutButton.Size = new System.Drawing.Size(362, 28);
+			this.AboutButton.TabIndex = 12;
+			this.AboutButton.Text = "About emuiibo and emutool";
+			this.AboutButton.UseVisualStyleBackColor = true;
+			this.AboutButton.Click += new System.EventHandler(this.AboutButton_Click);
+			// 
+			// MainForm
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(826, 589);
+			this.Controls.Add(this.AboutButton);
+			this.Controls.Add(this.statusStrip1);
+			this.Controls.Add(this.groupBox3);
+			this.Controls.Add(this.groupBox2);
+			this.Controls.Add(this.groupBox1);
+			this.Controls.Add(this.label3);
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+			this.MaximizeBox = false;
+			this.Name = "MainForm";
+			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+			this.Text = "Dummy";
+			this.groupBox2.ResumeLayout(false);
+			this.groupBox2.PerformLayout();
+			this.groupBox3.ResumeLayout(false);
+			this.groupBox3.PerformLayout();
+			this.statusStrip1.ResumeLayout(false);
+			this.statusStrip1.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.AmiiboPictureBox)).EndInit();
+			this.groupBox1.ResumeLayout(false);
+			this.groupBox1.PerformLayout();
+			this.ResumeLayout(false);
+			this.PerformLayout();
 
         }
 

--- a/emutool/emutool/MainForm.cs
+++ b/emutool/emutool/MainForm.cs
@@ -32,7 +32,7 @@ namespace emutool
         public MainForm()
         {
             InitializeComponent();
-            DialogCaption = "emutool v" + Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            DialogCaption = "emutool v" + Assembly.GetExecutingAssembly().GetName().Version;
             Text = DialogCaption + " - emuiibo's tool for virtual amiibo creation";
             Amiibos = AmiiboAPI.GetAllAmiibos();
 
@@ -47,7 +47,6 @@ namespace emutool
                     {
                         SeriesComboBox.Items.Add(series);
                     }
-                    SeriesComboBox.SelectedIndex = 0;
                 }
             }
             else
@@ -60,7 +59,7 @@ namespace emutool
             }
         }
 
-        private void ComboBox1_SelectedIndexChanged(object sender, EventArgs e)
+        private void SeriesComboBox_SelectedIndexChanged(object sender, EventArgs e)
         {
             AmiiboComboBox.Items.Clear();
 
@@ -79,7 +78,7 @@ namespace emutool
             }
         }
 
-        private void comboBox2_SelectedIndexChanged(object sender, EventArgs e)
+        private void AmiiboComboBox_SelectedIndexChanged(object sender, EventArgs e)
         {
             try
             {

--- a/emutool/emutool/Properties/AssemblyInfo.cs
+++ b/emutool/emutool/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // Puede especificar todos los valores o usar los valores predeterminados de número de compilación y de revisión
 // utilizando el carácter "*", como se muestra a continuación:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.2.0")]
-[assembly: AssemblyFileVersion("0.6.2.0")]
+[assembly: AssemblyVersion("0.6.2.1")]
+[assembly: AssemblyFileVersion("0.6.2.1")]
 [assembly: NeutralResourcesLanguage("en")]
 


### PR DESCRIPTION
I had a really hard time to find some special Animal Crossing Amiibos, so I couldn't take it any longer and improved the emutool a bit.

First, I added OrderBy to sort the Amiibos list by name, then I changed the dropdown style of the AmiiboComboBox to a DropDown and enabled the native AutoComplete feature of the WinForms ComboBox. These changes allow the user to search for an Amiibo by typing its name into the ComboBox.
I also removed the automatic selection of the first series in the SeriesComboBox. The way it was in the last release version, I think it's better that way.

I hope you find it useful too.