### PR TITLE
Add translation support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,4 @@ clean:
 
 translation:
 	$(CURDIR)/overlay/tools/translation.py update ru $(ARGS)
+	$(CURDIR)/overlay/tools/translation.py update es $(ARGS)

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,12 @@ all:
 	@cp $(CURDIR)/emuiibo/toolbox.json $(CURDIR)/SdOut/atmosphere/contents/0100000000000352/toolbox.json
 	@mkdir -p $(CURDIR)/SdOut/switch/.overlays
 	@cp $(CURDIR)/overlay/emuiibo.ovl $(CURDIR)/SdOut/switch/.overlays/emuiibo.ovl
+	@cp -r $(CURDIR)/overlay/emuiibo $(CURDIR)/SdOut/switch/.overlays/
 
 clean:
 	@rm -rf $(CURDIR)/SdOut
 	@cd emuiibo && cargo clean
 	@$(MAKE) clean -C overlay/
+
+translation:
+	$(CURDIR)/overlay/tools/translation.py update ru $(ARGS)

--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,4 @@ clean:
 	@$(MAKE) clean -C overlay/
 
 translation:
-	$(CURDIR)/overlay/tools/translation.py update ru $(ARGS)
-	$(CURDIR)/overlay/tools/translation.py update es $(ARGS)
+	$(CURDIR)/overlay/tools/translation.py update "*" $(ARGS)

--- a/overlay/emuiibo/lng_es.json
+++ b/overlay/emuiibo/lng_es.json
@@ -1,0 +1,100 @@
+{
+    "metadata": {
+        "base": "en",
+        "language": "es",
+        "created": "2021-4-18",
+        "author": "Impeeza"
+    },
+    "strings": [
+        {
+            "context": "",
+            "source": "Active virtual amiibo: ",
+            "translation": "Аmiibo virtual activo: "
+        },
+        {
+            "context": "",
+            "source": "No active virtual amiibo",
+            "translation": "No hay amiibo virtual activo"
+        },
+        {
+            "context": "",
+            "source": "emuiibo was not accessed.",
+            "translation": "emuiibo no pudo ser accedido."
+        },
+        {
+            "context": "",
+            "source": "Emulation: ",
+            "translation": "Emulación: "
+        },
+        {
+            "context": "",
+            "source": "on",
+            "translation": "Encendido"
+        },
+        {
+            "context": "",
+            "source": "No active virtual amiibo.",
+            "translation": "No se ha seleccionado un amiibo virtual."
+        },
+        {
+            "context": "",
+            "source": "Virtual amiibo: ",
+            "translation": "Amiibo virtual: "
+        },
+        {
+            "context": "",
+            "source": " (connected - select to disconnect)",
+            "translation": " (Conectado - Selecciónelo para desconectarlo)"
+        },
+        {
+            "context": "",
+            "source": " (disconnected - select to connect)",
+            "translation": " (Desconectado - Selecciónelo para conectarlo)"
+        },
+        {
+            "context": "",
+            "source": "Current game is being intercepted by emuiibo.",
+            "translation": "Emuiibo está interceptando el juego actual."
+        },
+        {
+            "context": "",
+            "source": "Current game is not being intercepted.",
+            "translation": "Emuiibo NO está interceptando el juego actual."
+        },
+        {
+            "context": "",
+            "source": "off",
+            "translation": "Apagado"
+        },
+        {
+            "context": "",
+            "source": "Available virtual amiibos",
+            "translation": "Virtual amiibos disponibles"
+        },
+        {
+            "context": "",
+            "source": "Available categories",
+            "translation": "Categorías disponibles"
+        },
+        {
+            "context": "",
+            "source": "Off",
+            "translation": "Apagado"
+        },
+        {
+            "context": "",
+            "source": "On",
+            "translation": "Encendido"
+        },
+        {
+            "context": "",
+            "source": "View amiibo",
+            "translation": "Ver amiibo"
+        },
+        {
+            "context": "",
+            "source": "Manage emulation (on / off)",
+            "translation": "Encender/Apagar emulación"
+        }
+    ]
+}

--- a/overlay/emuiibo/lng_ru.json
+++ b/overlay/emuiibo/lng_ru.json
@@ -1,0 +1,100 @@
+{
+    "metadata": {
+        "base": "en",
+        "language": "ru",
+        "created": "2021-2-11",
+        "author": "AmonRaNet"
+    },
+    "strings": [
+        {
+            "context": "",
+            "source": "Active virtual amiibo: ",
+            "translation": "Активный виртуальный amiibo: "
+        },
+        {
+            "context": "",
+            "source": "No active virtual amiibo",
+            "translation": "Виртуальный amiibo не выбран"
+        },
+        {
+            "context": "",
+            "source": "emuiibo was not accessed.",
+            "translation": "emuiibo не был доступен."
+        },
+        {
+            "context": "",
+            "source": "Emulation: ",
+            "translation": "Эмуляция: "
+        },
+        {
+            "context": "",
+            "source": "on",
+            "translation": "вкл"
+        },
+        {
+            "context": "",
+            "source": "No active virtual amiibo.",
+            "translation": "Виртуальный amiibo не выбран."
+        },
+        {
+            "context": "",
+            "source": "Virtual amiibo: ",
+            "translation": "Виртуальный amiibo: "
+        },
+        {
+            "context": "",
+            "source": " (connected - select to disconnect)",
+            "translation": " (подключено - выберите чтобы отключить)"
+        },
+        {
+            "context": "",
+            "source": " (disconnected - select to connect)",
+            "translation": " (отключено - выберите чтобы включить)"
+        },
+        {
+            "context": "",
+            "source": "Current game is being intercepted by emuiibo.",
+            "translation": "Текущая игра перехватывается emuiibo."
+        },
+        {
+            "context": "",
+            "source": "Current game is not being intercepted.",
+            "translation": "Текущая игра не перехватывается."
+        },
+        {
+            "context": "",
+            "source": "off",
+            "translation": "выкл"
+        },
+        {
+            "context": "",
+            "source": "Available virtual amiibos",
+            "translation": "Доступные виртуальные amiibos"
+        },
+        {
+            "context": "",
+            "source": "Available categories",
+            "translation": "Доступные категории"
+        },
+        {
+            "context": "",
+            "source": "Off",
+            "translation": "Выкл"
+        },
+        {
+            "context": "",
+            "source": "On",
+            "translation": "Вкл"
+        },
+        {
+            "context": "",
+            "source": "View amiibo",
+            "translation": "Просмотр amiibo"
+        },
+        {
+            "context": "",
+            "source": "Manage emulation (on / off)",
+            "translation": "Управление эмуляцией (вкл / выкл)"
+        }
+    ]
+}

--- a/overlay/emuiibo/lng_zh-Hant.json
+++ b/overlay/emuiibo/lng_zh-Hant.json
@@ -1,100 +1,100 @@
 {
     "metadata": {
         "base": "en",
-        "language": "es",
-        "created": "2021-4-18",
-        "author": "Impeeza"
+        "language": "cn",
+        "created": "2021-10-08",
+        "author": "amazingfate"
     },
     "strings": [
         {
             "context": "",
             "source": "Active virtual amiibo: ",
-            "translation": "Аmiibo virtual activo: "
+            "translation": "激活虚拟amiibo: "
         },
         {
             "context": "",
             "source": "No active virtual amiibo",
-            "translation": "No hay amiibo virtual activo"
+            "translation": "没有激活的虚拟amiibo"
         },
         {
             "context": "",
             "source": "emuiibo was not accessed.",
-            "translation": "emuiibo no pudo ser accedido."
+            "translation": "emuiibo不可用."
         },
         {
             "context": "",
             "source": "Emulation: ",
-            "translation": "Emulación: "
+            "translation": "模拟: "
         },
         {
             "context": "",
             "source": "on",
-            "translation": "Encendido"
+            "translation": "开启"
         },
         {
             "context": "",
             "source": "No active virtual amiibo.",
-            "translation": "No se ha seleccionado un amiibo virtual."
+            "translation": "没有激活的虚拟amiibo."
         },
         {
             "context": "",
             "source": "Virtual amiibo: ",
-            "translation": "Amiibo virtual: "
+            "translation": "虚拟amiibo: "
         },
         {
             "context": "",
             "source": " (connected - select to disconnect)",
-            "translation": " (Conectado - Selecciónelo para desconectarlo)"
+            "translation": " (已连接 - 选择以断开连接)"
         },
         {
             "context": "",
             "source": " (disconnected - select to connect)",
-            "translation": " (Desconectado - Selecciónelo para conectarlo)"
+            "translation": " (连接已断开 - 选择以连接)"
         },
         {
             "context": "",
             "source": "Current game is being intercepted by emuiibo.",
-            "translation": "Emuiibo está interceptando el juego actual."
+            "translation": "当前游戏emuiibo已生效."
         },
         {
             "context": "",
             "source": "Current game is not being intercepted.",
-            "translation": "Emuiibo NO está interceptando el juego actual."
+            "translation": "当前游戏emuiibo未生效."
         },
         {
             "context": "",
             "source": "off",
-            "translation": "Apagado"
+            "translation": "关闭"
         },
         {
             "context": "",
             "source": "Available virtual amiibos",
-            "translation": "Virtual amiibos disponibles"
+            "translation": "可用的虚拟amiibo"
         },
         {
             "context": "",
             "source": "Available categories",
-            "translation": "Categorías disponibles"
+            "translation": "可用的分类"
         },
         {
             "context": "",
             "source": "Off",
-            "translation": "Apagado"
+            "translation": "关闭"
         },
         {
             "context": "",
             "source": "On",
-            "translation": "Encendido"
+            "translation": "开启"
         },
         {
             "context": "",
             "source": "View amiibo",
-            "translation": "Ver amiibo"
+            "translation": "查看amiibo"
         },
         {
             "context": "",
             "source": "Manage emulation (on / off)",
-            "translation": "Encender/Apagar emulación"
+            "translation": "管理amiibo模拟 (开启 / 关闭)"
         }
     ]
 }

--- a/overlay/include/json.hpp
+++ b/overlay/include/json.hpp
@@ -1,0 +1,789 @@
+/*
+ *  -- SimpleJSON.hpp
+ *  Developed by: https://github.com/nbsdx/
+ *  Forked by: https://github.com/SealtielFreak/
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef JSON_HPP
+#define JSON_HPP
+
+#include <cstdint>
+#include <cmath>
+#include <cctype>
+#include <string>
+#include <deque>
+#include <map>
+#include <type_traits>
+#include <initializer_list>
+#include <ostream>
+#include <iostream>
+
+namespace json {
+
+    using std::map;
+    using std::deque;
+    using std::string;
+    using std::enable_if;
+    using std::initializer_list;
+    using std::is_same;
+    using std::is_convertible;
+    using std::is_integral;
+    using std::is_floating_point;
+
+    namespace {
+        string json_escape(const string &str) {
+            string output;
+            for (unsigned i = 0; i < str.length(); ++i)
+                switch (str[i]) {
+                    case '\"':
+                        output += "\\\"";
+                        break;
+                    case '\\':
+                        output += "\\\\";
+                        break;
+                    case '\b':
+                        output += "\\b";
+                        break;
+                    case '\f':
+                        output += "\\f";
+                        break;
+                    case '\n':
+                        output += "\\n";
+                        break;
+                    case '\r':
+                        output += "\\r";
+                        break;
+                    case '\t':
+                        output += "\\t";
+                        break;
+                    default  :
+                        output += str[i];
+                        break;
+                }
+            return std::move(output);
+        }
+    }
+
+    class JSON {
+        union BackingData {
+            BackingData(double d) : Float(d) {}
+
+            BackingData(long l) : Int(l) {}
+
+            BackingData(bool b) : Bool(b) {}
+
+            BackingData(string s) : String(new string(s)) {}
+
+            BackingData() : Int(0) {}
+
+            deque <JSON> *List;
+            map <string, JSON> *Map;
+            string *String;
+            double Float;
+            long Int;
+            bool Bool;
+        } Internal;
+
+    public:
+        enum class Class {
+            Null,
+            Object,
+            Array,
+            String,
+            Floating,
+            Integral,
+            Boolean
+        };
+
+        template<typename Container>
+        class JSONWrapper {
+            Container *object;
+
+        public:
+            JSONWrapper(Container *val) : object(val) {}
+
+            JSONWrapper(std::nullptr_t) : object(nullptr) {}
+
+            typename Container::iterator begin() { return object ? object->begin() : typename Container::iterator(); }
+
+            typename Container::iterator end() { return object ? object->end() : typename Container::iterator(); }
+
+            typename Container::const_iterator begin() const {
+                return object ? object->begin() : typename Container::iterator();
+            }
+
+            typename Container::const_iterator end() const {
+                return object ? object->end() : typename Container::iterator();
+            }
+        };
+
+        template<typename Container>
+        class JSONConstWrapper {
+            const Container *object;
+
+        public:
+            JSONConstWrapper(const Container *val) : object(val) {}
+
+            JSONConstWrapper(std::nullptr_t) : object(nullptr) {}
+
+            typename Container::const_iterator begin() const {
+                return object ? object->begin() : typename Container::const_iterator();
+            }
+
+            typename Container::const_iterator end() const {
+                return object ? object->end() : typename Container::const_iterator();
+            }
+        };
+
+        JSON() : Internal(), Type(Class::Null) {}
+
+        JSON(initializer_list <JSON> list)
+                : JSON() {
+            SetType(Class::Object);
+            for (auto i = list.begin(), e = list.end(); i != e; ++i, ++i)
+                operator[](i->ToString()) = *std::next(i);
+        }
+
+        JSON(JSON &&other)
+                : Internal(other.Internal), Type(other.Type) {
+            other.Type = Class::Null;
+            other.Internal.Map = nullptr;
+        }
+
+        JSON &operator=(JSON &&other) {
+            ClearInternal();
+            Internal = other.Internal;
+            Type = other.Type;
+            other.Internal.Map = nullptr;
+            other.Type = Class::Null;
+            return *this;
+        }
+
+        JSON(const JSON &other) {
+            switch (other.Type) {
+                case Class::Object:
+                    Internal.Map =
+                            new map<string, JSON>(other.Internal.Map->begin(),
+                                                  other.Internal.Map->end());
+                    break;
+                case Class::Array:
+                    Internal.List =
+                            new deque<JSON>(other.Internal.List->begin(),
+                                            other.Internal.List->end());
+                    break;
+                case Class::String:
+                    Internal.String =
+                            new string(*other.Internal.String);
+                    break;
+                default:
+                    Internal = other.Internal;
+            }
+            Type = other.Type;
+        }
+
+        JSON &operator=(const JSON &other) {
+            ClearInternal();
+            switch (other.Type) {
+                case Class::Object:
+                    Internal.Map =
+                            new map<string, JSON>(other.Internal.Map->begin(),
+                                                  other.Internal.Map->end());
+                    break;
+                case Class::Array:
+                    Internal.List =
+                            new deque<JSON>(other.Internal.List->begin(),
+                                            other.Internal.List->end());
+                    break;
+                case Class::String:
+                    Internal.String =
+                            new string(*other.Internal.String);
+                    break;
+                default:
+                    Internal = other.Internal;
+            }
+            Type = other.Type;
+            return *this;
+        }
+
+        ~JSON() {
+            switch (Type) {
+                case Class::Array:
+                    delete Internal.List;
+                    break;
+                case Class::Object:
+                    delete Internal.Map;
+                    break;
+                case Class::String:
+                    delete Internal.String;
+                    break;
+                default:;
+            }
+        }
+
+        template<typename T>
+        JSON(T b, typename enable_if<is_same<T, bool>::value>::type * = 0) : Internal(b), Type(Class::Boolean) {}
+
+        template<typename T>
+        JSON(T i, typename enable_if<is_integral<T>::value && !is_same<T, bool>::value>::type * = 0) : Internal(
+                (long) i), Type(Class::Integral) {}
+
+        template<typename T>
+        JSON(T f, typename enable_if<is_floating_point<T>::value>::type * = 0) : Internal((double) f),
+                                                                                 Type(Class::Floating) {}
+
+        template<typename T>
+        JSON(T s, typename enable_if<is_convertible<T, string>::value>::type * = 0) : Internal(string(s)),
+                                                                                      Type(Class::String) {}
+
+        JSON(std::nullptr_t) : Internal(), Type(Class::Null) {}
+
+        static JSON Make(Class type) {
+            JSON ret;
+            ret.SetType(type);
+            return ret;
+        }
+
+        static JSON Load(const string &);
+
+        template<typename T>
+        void append(T arg) {
+            SetType(Class::Array);
+            Internal.List->emplace_back(arg);
+        }
+
+        template<typename T, typename... U>
+        void append(T arg, U... args) {
+            append(arg);
+            append(args...);
+        }
+
+        template<typename T>
+        typename enable_if<is_same<T, bool>::value, JSON &>::type operator=(T b) {
+            SetType(Class::Boolean);
+            Internal.Bool = b;
+            return *this;
+        }
+
+        template<typename T>
+        typename enable_if<is_integral<T>::value && !is_same<T, bool>::value, JSON &>::type operator=(T i) {
+            SetType(Class::Integral);
+            Internal.Int = i;
+            return *this;
+        }
+
+        template<typename T>
+        typename enable_if<is_floating_point<T>::value, JSON &>::type operator=(T f) {
+            SetType(Class::Floating);
+            Internal.Float = f;
+            return *this;
+        }
+
+        template<typename T>
+        typename enable_if<is_convertible<T, string>::value, JSON &>::type operator=(T s) {
+            SetType(Class::String);
+            *Internal.String = string(s);
+            return *this;
+        }
+
+        JSON &operator[](const string &key) {
+            SetType(Class::Object);
+            return Internal.Map->operator[](key);
+        }
+
+        JSON &operator[](unsigned index) {
+            SetType(Class::Array);
+            if (index >= Internal.List->size()) Internal.List->resize(index + 1);
+            return Internal.List->operator[](index);
+        }
+
+        JSON &at(const string &key) {
+            return operator[](key);
+        }
+
+        const JSON &at(const string &key) const {
+            return Internal.Map->at(key);
+        }
+
+        JSON &at(unsigned index) {
+            return operator[](index);
+        }
+
+        const JSON &at(unsigned index) const {
+            return Internal.List->at(index);
+        }
+
+        int length() const {
+            if (Type == Class::Array)
+                return Internal.List->size();
+            else
+                return -1;
+        }
+
+        bool hasKey(const string &key) const {
+            if (Type == Class::Object)
+                return Internal.Map->find(key) != Internal.Map->end();
+            return false;
+        }
+
+        int size() const {
+            if (Type == Class::Object)
+                return Internal.Map->size();
+            else if (Type == Class::Array)
+                return Internal.List->size();
+            else
+                return -1;
+        }
+
+        Class JSONType() const { return Type; }
+
+        /// Functions for getting primitives from the JSON object.
+        bool IsNull() const { return Type == Class::Null; }
+
+        string ToString() const {
+            bool b;
+            return std::move(ToString(b));
+        }
+
+        string ToString(bool &ok) const {
+            ok = (Type == Class::String);
+            return ok ? std::move(json_escape(*Internal.String)) : string("");
+        }
+
+        double ToFloat() const {
+            bool b;
+            return ToFloat(b);
+        }
+
+        double ToFloat(bool &ok) const {
+            ok = (Type == Class::Floating);
+            return ok ? Internal.Float : 0.0;
+        }
+
+        long ToInt() const {
+            bool b;
+            return ToInt(b);
+        }
+
+        long ToInt(bool &ok) const {
+            ok = (Type == Class::Integral);
+            return ok ? Internal.Int : 0;
+        }
+
+        bool ToBool() const {
+            bool b;
+            return ToBool(b);
+        }
+
+        bool ToBool(bool &ok) const {
+            ok = (Type == Class::Boolean);
+            return ok ? Internal.Bool : false;
+        }
+
+        JSONWrapper<map < string, JSON>> ObjectRange() {
+            if (Type == Class::Object)
+                return JSONWrapper<map < string, JSON>>
+            (Internal.Map);
+            return JSONWrapper<map < string, JSON>>
+            (nullptr);
+        }
+
+        JSONWrapper<deque < JSON>> ArrayRange() {
+            if (Type == Class::Array)
+                return JSONWrapper<deque < JSON>>
+            (Internal.List);
+            return JSONWrapper<deque < JSON>>
+            (nullptr);
+        }
+
+        JSONConstWrapper<map < string, JSON>> ObjectRange() const {
+            if (Type == Class::Object)
+                return JSONConstWrapper<map < string, JSON>>
+            (Internal.Map);
+            return JSONConstWrapper<map < string, JSON>>
+            (nullptr);
+        }
+
+
+        JSONConstWrapper<deque < JSON>> ArrayRange() const {
+            if (Type == Class::Array)
+                return JSONConstWrapper<deque < JSON>>
+            (Internal.List);
+            return JSONConstWrapper<deque < JSON>>
+            (nullptr);
+        }
+
+        string dump(int depth = 1, string tab = "  ") const {
+            string pad = "";
+            for (int i = 0; i < depth; ++i, pad += tab);
+
+            switch (Type) {
+                case Class::Null:
+                    return "null";
+                case Class::Object: {
+                    string s = "{\n";
+                    bool skip = true;
+                    for (auto &p : *Internal.Map) {
+                        if (!skip) s += ",\n";
+                        s += (pad + "\"" + p.first + "\" : " + p.second.dump(depth + 1, tab));
+                        skip = false;
+                    }
+                    s += ("\n" + pad.erase(0, 2) + "}");
+                    return s;
+                }
+                case Class::Array: {
+                    string s = "[";
+                    bool skip = true;
+                    for (auto &p : *Internal.List) {
+                        if (!skip) s += ", ";
+                        s += p.dump(depth + 1, tab);
+                        skip = false;
+                    }
+                    s += "]";
+                    return s;
+                }
+                case Class::String:
+                    return "\"" + json_escape(*Internal.String) + "\"";
+                case Class::Floating:
+                    return std::to_string(Internal.Float);
+                case Class::Integral:
+                    return std::to_string(Internal.Int);
+                case Class::Boolean:
+                    return Internal.Bool ? "true" : "false";
+                default:
+                    return "";
+            }
+            return "";
+        }
+
+        friend std::ostream &operator<<(std::ostream &, const JSON &);
+
+    private:
+        void SetType(Class type) {
+            if (type == Type)
+                return;
+
+            ClearInternal();
+
+            switch (type) {
+                case Class::Null:
+                    Internal.Map = nullptr;
+                    break;
+                case Class::Object:
+                    Internal.Map = new map<string, JSON>();
+                    break;
+                case Class::Array:
+                    Internal.List = new deque<JSON>();
+                    break;
+                case Class::String:
+                    Internal.String = new string();
+                    break;
+                case Class::Floating:
+                    Internal.Float = 0.0;
+                    break;
+                case Class::Integral:
+                    Internal.Int = 0;
+                    break;
+                case Class::Boolean:
+                    Internal.Bool = false;
+                    break;
+            }
+
+            Type = type;
+        }
+
+    private:
+        /* beware: only call if YOU know that Internal is allocated. No checks performed here.
+           This function should be called in a constructed JSON just before you are going to
+          overwrite Internal...
+        */
+        void ClearInternal() {
+            switch (Type) {
+                case Class::Object:
+                    delete Internal.Map;
+                    break;
+                case Class::Array:
+                    delete Internal.List;
+                    break;
+                case Class::String:
+                    delete Internal.String;
+                    break;
+                default:;
+            }
+        }
+
+    private:
+
+        Class Type = Class::Null;
+    };
+
+    JSON Array() {
+        return std::move(JSON::Make(JSON::Class::Array));
+    }
+
+    template<typename... T>
+    JSON Array(T... args) {
+        JSON arr = JSON::Make(JSON::Class::Array);
+        arr.append(args...);
+        return std::move(arr);
+    }
+
+    JSON Object() {
+        return std::move(JSON::Make(JSON::Class::Object));
+    }
+
+    std::ostream &operator<<(std::ostream &os, const JSON &json) {
+        os << json.dump();
+        return os;
+    }
+
+    namespace {
+        JSON parse_next(const string &, size_t &);
+
+        void consume_ws(const string &str, size_t &offset) {
+            while (isspace(str[offset])) ++offset;
+        }
+
+        JSON parse_object(const string &str, size_t &offset) {
+            JSON Object = JSON::Make(JSON::Class::Object);
+
+            ++offset;
+            consume_ws(str, offset);
+            if (str[offset] == '}') {
+                ++offset;
+                return std::move(Object);
+            }
+
+            while (true) {
+                JSON Key = parse_next(str, offset);
+                consume_ws(str, offset);
+                if (str[offset] != ':') {
+                    std::cerr << "Error: Object: Expected colon, found '" << str[offset] << "'\n";
+                    break;
+                }
+                consume_ws(str, ++offset);
+                JSON Value = parse_next(str, offset);
+                Object[Key.ToString()] = Value;
+
+                consume_ws(str, offset);
+                if (str[offset] == ',') {
+                    ++offset;
+                    continue;
+                } else if (str[offset] == '}') {
+                    ++offset;
+                    break;
+                } else {
+                    std::cerr << "ERROR: Object: Expected comma, found '" << str[offset] << "'\n";
+                    break;
+                }
+            }
+
+            return std::move(Object);
+        }
+
+        JSON parse_array(const string &str, size_t &offset) {
+            JSON Array = JSON::Make(JSON::Class::Array);
+            unsigned index = 0;
+
+            ++offset;
+            consume_ws(str, offset);
+            if (str[offset] == ']') {
+                ++offset;
+                return std::move(Array);
+            }
+
+            while (true) {
+                Array[index++] = parse_next(str, offset);
+                consume_ws(str, offset);
+
+                if (str[offset] == ',') {
+                    ++offset;
+                    continue;
+                } else if (str[offset] == ']') {
+                    ++offset;
+                    break;
+                } else {
+                    std::cerr << "ERROR: Array: Expected ',' or ']', found '" << str[offset] << "'\n";
+                    return std::move(JSON::Make(JSON::Class::Array));
+                }
+            }
+
+            return std::move(Array);
+        }
+
+        JSON parse_string(const string &str, size_t &offset) {
+            JSON String;
+            string val;
+            for (char c = str[++offset]; c != '\"'; c = str[++offset]) {
+                if (c == '\\') {
+                    switch (str[++offset]) {
+                        case '\"':
+                            val += '\"';
+                            break;
+                        case '\\':
+                            val += '\\';
+                            break;
+                        case '/' :
+                            val += '/';
+                            break;
+                        case 'b' :
+                            val += '\b';
+                            break;
+                        case 'f' :
+                            val += '\f';
+                            break;
+                        case 'n' :
+                            val += '\n';
+                            break;
+                        case 'r' :
+                            val += '\r';
+                            break;
+                        case 't' :
+                            val += '\t';
+                            break;
+                        case 'u' : {
+                            val += "\\u";
+                            for (unsigned i = 1; i <= 4; ++i) {
+                                c = str[offset + i];
+                                if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))
+                                    val += c;
+                                else {
+                                    std::cerr << "ERROR: String: Expected hex character in unicode escape, found '" << c
+                                              << "'\n";
+                                    return std::move(JSON::Make(JSON::Class::String));
+                                }
+                            }
+                            offset += 4;
+                        }
+                            break;
+                        default  :
+                            val += '\\';
+                            break;
+                    }
+                } else
+                    val += c;
+            }
+            ++offset;
+            String = val;
+            return std::move(String);
+        }
+
+        JSON parse_number(const string &str, size_t &offset) {
+            JSON Number;
+            string val, exp_str;
+            char c;
+            bool isDouble = false;
+            long exp = 0;
+            while (true) {
+                c = str[offset++];
+                if ((c == '-') || (c >= '0' && c <= '9'))
+                    val += c;
+                else if (c == '.') {
+                    val += c;
+                    isDouble = true;
+                } else
+                    break;
+            }
+            if (c == 'E' || c == 'e') {
+                c = str[offset++];
+                if (c == '-') {
+                    ++offset;
+                    exp_str += '-';
+                }
+                while (true) {
+                    c = str[offset++];
+                    if (c >= '0' && c <= '9')
+                        exp_str += c;
+                    else if (!isspace(c) && c != ',' && c != ']' && c != '}') {
+                        std::cerr << "ERROR: Number: Expected a number for exponent, found '" << c << "'\n";
+                        return std::move(JSON::Make(JSON::Class::Null));
+                    } else
+                        break;
+                }
+                exp = std::stol(exp_str);
+            } else if (!isspace(c) && c != ',' && c != ']' && c != '}') {
+                std::cerr << "ERROR: Number: unexpected character '" << c << "'\n";
+                return std::move(JSON::Make(JSON::Class::Null));
+            }
+            --offset;
+
+            if (isDouble)
+                Number = std::stod(val) * std::pow(10, exp);
+            else {
+                if (!exp_str.empty())
+                    Number = std::stol(val) * std::pow(10, exp);
+                else
+                    Number = std::stol(val);
+            }
+            return std::move(Number);
+        }
+
+        JSON parse_bool(const string &str, size_t &offset) {
+            JSON Bool;
+            if (str.substr(offset, 4) == "true")
+                Bool = true;
+            else if (str.substr(offset, 5) == "false")
+                Bool = false;
+            else {
+                std::cerr << "ERROR: Bool: Expected 'true' or 'false', found '" << str.substr(offset, 5) << "'\n";
+                return std::move(JSON::Make(JSON::Class::Null));
+            }
+            offset += (Bool.ToBool() ? 4 : 5);
+            return std::move(Bool);
+        }
+
+        JSON parse_null(const string &str, size_t &offset) {
+            JSON Null;
+            if (str.substr(offset, 4) != "null") {
+                std::cerr << "ERROR: Null: Expected 'null', found '" << str.substr(offset, 4) << "'\n";
+                return std::move(JSON::Make(JSON::Class::Null));
+            }
+            offset += 4;
+            return std::move(Null);
+        }
+
+        JSON parse_next(const string &str, size_t &offset) {
+            char value;
+            consume_ws(str, offset);
+            value = str[offset];
+            switch (value) {
+                case '[' :
+                    return std::move(parse_array(str, offset));
+                case '{' :
+                    return std::move(parse_object(str, offset));
+                case '\"':
+                    return std::move(parse_string(str, offset));
+                case 't' :
+                case 'f' :
+                    return std::move(parse_bool(str, offset));
+                case 'n' :
+                    return std::move(parse_null(str, offset));
+                default  :
+                    if ((value <= '9' && value >= '0') || value == '-')
+                        return std::move(parse_number(str, offset));
+            }
+            std::cerr << "ERROR: Parse: Unknown starting character '" << value << "'\n";
+            return JSON();
+        }
+    }
+
+    JSON JSON::Load(const string &str) {
+        size_t offset = 0;
+        return std::move(parse_next(str, offset));
+    }
+
+} // End Namespace json
+
+#endif // JSON_HPP

--- a/overlay/include/translation.h
+++ b/overlay/include/translation.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#define TR(SOURCE) Translator::translate(SOURCE)
+#define TR_CTX(SOURCE, CONTEXT) Translator::translate(SOURCE, CONTEXT)
+
+class Translator {
+
+public:
+    static Translator& global();
+    static std::string translate(const std::string& source, const std::string& context = {});
+
+    void loadSystem();
+
+    //https://switchbrew.org/wiki/Settings_services#LanguageCode
+    void loadCustom(const std::string& lng);
+
+    std::string get(const std::string& source, const std::string& context) const;
+
+private:
+    std::string language;
+    std::unordered_map<std::string, std::unordered_map<std::string, std::string>> strings;
+};

--- a/overlay/source/Main.cpp
+++ b/overlay/source/Main.cpp
@@ -3,6 +3,7 @@
 #include <emuiibo.hpp>
 #include <libtesla_ext.hpp>
 #include <dirent.h>
+#include <translation.h>
 
 namespace {
 
@@ -36,9 +37,9 @@ namespace {
 
     inline std::string MakeActiveAmiiboText() {
         if(IsActiveAmiiboValid()) {
-            return std::string("Active virtual amiibo: ") + g_ActiveVirtualAmiiboData.name;
+            return TR("Active virtual amiibo: ") + g_ActiveVirtualAmiiboData.name;
         }
-        return "No active virtual amiibo";
+        return TR("No active virtual amiibo");
     }
 
     inline std::string MakeTitleText() {
@@ -50,43 +51,43 @@ namespace {
 
     inline std::string MakeStatusText() {
         if(!g_Initialized) {
-            return "emuiibo was not accessed.";
+            return TR("emuiibo was not accessed.");
         }
-        std::string msg = "Emulation: ";
+        std::string msg = TR("Emulation: ");
         auto e_status = emu::GetEmulationStatus();
         switch(e_status) {
             case emu::EmulationStatus::On: {
-                msg += "on\n";
+                msg += TR("on") + "\n";
                 auto v_status = emu::GetActiveVirtualAmiiboStatus();
                 switch(v_status) {
                     case emu::VirtualAmiiboStatus::Invalid: {
-                        msg += "No active virtual amiibo.";
+                        msg += TR("No active virtual amiibo.");
                         break;
                     }
                     case emu::VirtualAmiiboStatus::Connected: {
-                        msg += "Virtual amiibo: ";
+                        msg += TR("Virtual amiibo: ");
                         msg += g_ActiveVirtualAmiiboData.name;
-                        msg += " (connected - select to disconnect)";
+                        msg += TR(" (connected - select to disconnect)");
                         break;
                     }
                     case emu::VirtualAmiiboStatus::Disconnected: {
-                        msg += "Virtual amiibo: ";
+                        msg += TR("Virtual amiibo: ");
                         msg += g_ActiveVirtualAmiiboData.name;
-                        msg += " (disconnected - select to connect)";
+                        msg += TR(" (disconnected - select to connect)");
                         break;
                     }
                 }
                 msg += "\n";
                 if(g_CurrentApplicationIntercepted) {
-                    msg += "Current game is being intercepted by emuiibo.";
+                    msg += TR("Current game is being intercepted by emuiibo.");
                 }
                 else {
-                    msg += "Current game is not being intercepted.";
+                    msg += TR("Current game is not being intercepted.");
                 }
                 break;
             }
             case emu::EmulationStatus::Off: {
-                msg += "off";
+                msg += TR("off");
                 break;
             }
         }
@@ -138,7 +139,7 @@ class AmiiboList : public tsl::Gui {
                 UpdateActiveAmiibo();
                 selected_header->setText(MakeActiveAmiiboText());
                 root_frame->setSubtitle(MakeStatusText());
-                return true;   
+                return true;
             }
             return false;
         }
@@ -173,7 +174,7 @@ class AmiiboList : public tsl::Gui {
             });
 
             selected_header = new tsl::elm::BigCategoryHeader(MakeActiveAmiiboText(), true);
-            count_header = new tsl::elm::CategoryHeader("Available virtual amiibos (" + std::to_string(count) + ")", true);
+            count_header = new tsl::elm::CategoryHeader(TR("Available virtual amiibos")+ " (" + std::to_string(count) + ")", true);
 
             header_list->addItem(selected_header);
             header_list->addItem(count_header);
@@ -254,7 +255,7 @@ class CategoryList : public tsl::Gui {
                 }
             });
 
-            this->count_header = new tsl::elm::CategoryHeader("Available categories (" + std::to_string(count) + ")", true);
+            this->count_header = new tsl::elm::CategoryHeader(TR("Available categories") + " (" + std::to_string(count) + ")", true);
 
             header_list->addItem(this->selected_header);
             header_list->addItem(this->count_header);
@@ -296,12 +297,12 @@ class MainGui : public tsl::Gui {
 
         virtual tsl::elm::Element *createUI() override {
             auto list = new tsl::elm::List();
-            
+
             if(g_Initialized) {
                 auto status = emu::GetEmulationStatus();
 
-                auto *toggle_item = new tsl::elm::NamedStepTrackBar("\u22EF", { "Off", "On" });
-                auto *select_item = new tsl::elm::SmallListItem("View amiibo");
+                auto *toggle_item = new tsl::elm::NamedStepTrackBar("\u22EF", { TR("Off"), TR("On") });
+                auto *select_item = new tsl::elm::SmallListItem(TR("View amiibo"));
 
                 u8 toggle_progress;
                 switch(status) {
@@ -337,7 +338,7 @@ class MainGui : public tsl::Gui {
                     return false;
                 });
 
-                list->addItem(new tsl::elm::BigCategoryHeader("Manage emulation (on / off)", true));
+                list->addItem(new tsl::elm::BigCategoryHeader(TR("Manage emulation (on / off)"), true));
                 list->addItem(toggle_item);
                 list->addItem(this->amiibo_header);
                 list->addItem(select_item);
@@ -382,14 +383,15 @@ class Overlay : public tsl::Overlay {
             if(g_Initialized) {
                 UpdateActiveAmiibo();
             }
+            Translator::global().loadSystem();
         }
-        
+
         virtual void exitServices() override {
             pminfoExit();
             pmdmntExit();
             emu::Exit();
         }
-        
+
         virtual std::unique_ptr<tsl::Gui> loadInitialGui() override {
             return initially<MainGui>();
         }

--- a/overlay/source/Main.cpp
+++ b/overlay/source/Main.cpp
@@ -328,8 +328,8 @@ class MainGui : public tsl::Gui {
                     }
                     this->Refresh();
                 });
-                
-                select_item->setClickListener([](u64 keys) { 
+
+                select_item->setClickListener([](u64 keys) {
                     if(keys & HidNpadButton_A) {
                         tsl::changeTo<CategoryList>();
                         g_NeedsUpdateMainGui = true;

--- a/overlay/source/translation.cpp
+++ b/overlay/source/translation.cpp
@@ -1,0 +1,79 @@
+extern "C" {
+#include <switch.h>
+#include <cstring>
+#define MIN_LNG_SIZE sizeof(u64) + 1
+void GetSystemLanguage(char* lng) {
+    u64 s_textLanguageCode = 0;
+    Result rc = setInitialize();
+    if (R_SUCCEEDED(rc)) rc = setGetSystemLanguage(&s_textLanguageCode);
+    setExit();
+    memset(lng, 0x00, MIN_LNG_SIZE);
+    memcpy(lng, (void*)&s_textLanguageCode, sizeof(s_textLanguageCode));
+}
+}
+
+#include <switch.h>
+#include <tesla.hpp>
+#include <translation.h>
+#include <filesystem>
+#include <fstream>
+#include <streambuf>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpessimizing-move"
+#include <json.hpp>
+#pragma GCC diagnostic pop
+
+Translator& Translator::global() {
+    static Translator glTr;
+    return glTr;
+}
+
+std::string Translator::translate(const std::string& source, const std::string& context) {
+    return global().get(source, context);
+}
+
+void Translator::loadSystem() {
+    char lng[MIN_LNG_SIZE];
+    GetSystemLanguage(lng);
+    loadCustom(lng);
+}
+
+void Translator::loadCustom(const std::string& lng) {
+    if (language == lng) {
+        return;
+    }
+    language = lng;
+    strings.clear();
+
+    tsl::hlp::doWithSDCardHandle([this] {
+        std::filesystem::path lng_file{"sdmc:/switch/.overlays/emuiibo/lng_" + language + ".json"};
+        if (!std::filesystem::exists(lng_file)) {
+            return;
+        }
+
+        std::ifstream json_file(lng_file);
+        const std::string json_string((std::istreambuf_iterator<char>(json_file)),
+                                std::istreambuf_iterator<char>());
+        auto json_all = json::JSON::Load(json_string);
+        for (auto json_string: json_all["strings"].ArrayRange()) {
+            const auto context = json_string["context"].ToString();
+            const auto source = json_string["source"].ToString();
+            const auto translation = json_string["translation"].ToString();
+            strings[context][source] = translation;
+        }
+    });
+}
+
+std::string Translator::get(const std::string& source, const std::string& context) const {
+    if (strings.count(context) == 0) {
+        return source;
+    }
+    if (strings.at(context).count(source) == 0) {
+        return source;
+    }
+    if (strings.at(context).at(source).empty()) {
+        return source;
+    }
+    return strings.at(context).at(source);
+}

--- a/overlay/tools/translation.py
+++ b/overlay/tools/translation.py
@@ -1,0 +1,221 @@
+#! /usr/bin/env python3
+
+import argparse
+import sys, os
+import re
+import json
+import collections
+import datetime
+
+PATH = os.path.abspath(os.path.dirname(__file__))
+
+
+class Translation:
+    def __init__(self, language):
+        self.language = language
+        self.keys = {}
+
+    def __str__(self):
+        result = "For language '%s':" % (self.language)
+        for ctx in self.ctx_list():
+            for source in self.sources_list(ctx):
+                translation = self.translation(ctx, source)
+                is_used = self.is_used(ctx, source)
+                special_characters_check = self.special_characters_check(source, translation)
+                result += '\n'
+                result += "%s " % (self.language)
+                if ctx is not "":
+                    result += "(%s) '%s'" % (ctx, source)
+                else:
+                    result += "'%s'" % (source)
+                if translation is None:
+                    result += " ! <not translated>"
+                else:
+                    result += " = '%s'" % (translation)
+                if not is_used:
+                    result += " ! <not used>"
+                if not special_characters_check:
+                    result += " ! <special characters mismatch>"
+        return result
+
+    def set(self, ctx, source, translation, is_used):
+        if ctx not in self.keys:
+            self.keys[ctx] = {}
+        if source not in self.keys[ctx]:
+            self.keys[ctx][source] = collections.namedtuple('Translation', 'translation is_used')
+        self.keys[ctx][source].translation = translation
+        self.keys[ctx][source].is_used = is_used
+
+    def translation(self, ctx, source):
+        if not self.is_exists(ctx, source):
+            return None
+        return self.keys[ctx][source].translation
+
+    def is_used(self, ctx, source):
+        if not self.is_exists(ctx, source):
+            return False
+        return self.keys[ctx][source].is_used
+
+    def special_characters_check(self, source, translation):
+        if source is None or translation is None:
+            return True
+        r = re.compile(r'[\.\,\:\;\\\/\(\)\[\]\{\}\?\!\&\%\"\'\*\+\~\<\>\|\=\-\r\n\t]')
+        count_source = collections.Counter(r.findall(source))
+        translation_source = collections.Counter(r.findall(translation))
+        return count_source == translation_source
+
+    def is_exists(self, ctx, source):
+        if ctx not in self.keys:
+            return False
+        if source not in self.keys[ctx]:
+            return False
+        return True
+
+    def ctx_list(self):
+        return self.keys.keys()
+
+    def sources_list(self, ctx):
+        if ctx not in self.keys:
+            return {}
+        return self.keys[ctx].keys()
+
+    def merge(self, addition, only_existing):
+        for ctx in addition.ctx_list():
+            for source in addition.sources_list(ctx):
+                translation = addition.translation(ctx, source)
+                is_used = addition.is_used(ctx, source)
+                exists = self.is_exists(ctx, source)
+                if exists:
+                    self.set(ctx, source, translation, True)
+                else:
+                    if not only_existing:
+                        self.set(ctx, source, translation, is_used)
+
+
+def load_sources(language):
+    used_keys = Translation(language)
+    file = open(PATH + '/../source/Main.cpp', 'r')
+    lines = file.readlines()
+    for line in lines:
+        r = re.compile(r'TR\(\s*"(.*?)"\s*\)')
+        pos = 0
+        while True:
+            m = r.search(line, pos)
+            if m is not None:
+                pos = m.span()[1]
+                ctx = ""
+                source = m.group(1)
+                used_keys.set(ctx, source, None, True)
+            else:
+                break
+        r = re.compile(r'TR_CTX\(\s*"(.*?)"\s*,\s*"(.*?)"\s*\)')
+        pos = 0
+        while True:
+            m = r.search(line, pos)
+            if m is not None:
+                pos = m.span()[1]
+                ctx = m.group(2)
+                source = m.group(1)
+                used_keys.set(ctx, source, None, True)
+            else:
+                break
+    return used_keys
+
+
+def load_translation(language):
+    given_keys = Translation(language)
+    metadata = None
+    file_name = PATH + '/../emuiibo/lng_' + language + '.json'
+    try:
+        file = open(file_name)
+        data = json.load(file)
+        metadata = data['metadata']
+        for str_entry in data['strings']:
+            ctx = str_entry['context']
+            source = str_entry['source']
+            translation = str_entry['translation']
+            given_keys.set(ctx, source, translation, False)
+    except:
+        print('%s not exists' % (file_name))
+    return (given_keys, metadata)
+
+
+def save_translation(language, result_keys, metadata):
+    file_name = PATH + '/../emuiibo/lng_' + language + '.json'
+    try:
+        data = {}
+        if metadata is None:
+            now =  datetime.datetime.now()
+            data['metadata'] = {}
+            data['metadata']['base'] = 'en'
+            data['metadata']['language'] = language
+            data['metadata']['created'] = "{}-{}-{}".format(now.year, now.month, now.day)
+            data['metadata']['author'] = ""
+        else:
+            data['metadata'] = metadata
+        data['strings'] = []
+        for ctx in result_keys.ctx_list():
+            for source in result_keys.sources_list(ctx):
+                translation = result_keys.translation(ctx, source)
+                data['strings'].append({
+                'context' : ctx,
+                'source' : source,
+                'translation' : translation})
+        file = open(file_name, 'w+')
+        json.dump(data, file, indent=4, ensure_ascii=False)
+        print('%s was created/updated' % (file_name))
+    except:
+        print('%s was not created' % (file_name))
+
+
+def check_language(language):
+    ava_lang = {
+        "ja": "Japanese",
+        "en-US": "AmericanEnglish",
+        "fr": "French",
+        "de": "German",
+        "it": "Italian",
+        "es": "Spanish",
+        "zh-CN": "Chinese",
+        "ko": "Korean",
+        "nl": "Dutch",
+        "pt": "Portuguese",
+        "ru": "Russian",
+        "zh-TW": "Taiwanese",
+        "en-GB": "BritishEnglish",
+        "fr-CA": "CanadianFrench",
+        "es-419": "LatinAmericanSpanish",
+        "zh-Hans": "[4.0.0+] SimplifiedChinese",
+        "zh-Hant": "[4.0.0+] TraditionalChinese",
+        "pt-BR": "[10.1.0+] BrazilianPortuguese",
+    };
+    if language not in ava_lang.keys():
+        raise Exception("Language code '%s' is wrong. Allowed: %s" % (language, ava_lang))
+
+
+def update(parser):
+    language = parser.language
+    check_language(language)
+    remove_unused = parser.remove_unused
+    used_keys = load_sources(language)
+    (given_keys, metadata) = load_translation(language)
+    result_keys = Translation(language)
+    result_keys.merge(used_keys, False)
+    result_keys.merge(given_keys, remove_unused)
+    save_translation(language, result_keys, metadata)
+    print(result_keys)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='command', help='Subcommand to run')
+
+    parser_update = subparsers.add_parser('update')
+    parser_update.add_argument(
+        '--remove-unused', action='store_true', help='Remove unused keys')
+    parser_update.add_argument(
+        'language', help='Language according https://switchbrew.org/wiki/Settings_services#LanguageCode')
+    parser_update.set_defaults(func=update)
+
+    options = parser.parse_args()
+    options.func(options)

--- a/overlay/tools/translation.py
+++ b/overlay/tools/translation.py
@@ -193,10 +193,8 @@ def check_language(language):
         raise Exception("Language code '%s' is wrong. Allowed: %s" % (language, ava_lang))
 
 
-def update(parser):
-    language = parser.language
+def updateOne(language, remove_unused):
     check_language(language)
-    remove_unused = parser.remove_unused
     used_keys = load_sources(language)
     (given_keys, metadata) = load_translation(language)
     result_keys = Translation(language)
@@ -204,6 +202,22 @@ def update(parser):
     result_keys.merge(given_keys, remove_unused)
     save_translation(language, result_keys, metadata)
     print(result_keys)
+
+
+def update(parser):
+    language = parser.language
+    remove_unused = parser.remove_unused
+    if language is not "*":
+        updateOne(language, remove_unused)
+        return
+
+    base_path = PATH + '/../emuiibo/'
+    files = [f for f in os.listdir(base_path) if os.path.isfile(os.path.join(base_path, f))]
+    print('Detected: %s' % (files))
+    for language in files:
+        language = re.sub('lng_', '', language)
+        language = re.sub('.json', '', language)
+        updateOne(language, remove_unused)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added support for localization.
I have used Qt like style (base strings in code) - I see as more readable in-comparison to ID based solutions.
To support fast update/create of translation extra make command added: make translation . Currently command updates only Russian language, other can be added in similar way.

TR - default(empty) context
TR_CTX - custom context. Can be used to group strings or to add several translations for same source

P.S. 
 - Russian is translated
 - Spanish is translated (thanks to @impeeza)
