### PR TITLE
Possible fix for #142

### DIFF
--- a/emutool/emutool/MainForm.cs
+++ b/emutool/emutool/MainForm.cs
@@ -234,16 +234,11 @@ namespace emutool
         {
             try
             {
-                string base_dir = null;
-                if(!FtpSaveCheck.Checked)
+                string base_dir = SelectDirectory();
+                if(base_dir == null)
                 {
-                    // If we're saving normally and we're not using the last path, ask the user for the path
-                    base_dir = SelectDirectory();
-                    if(base_dir == null)
-                    {
-                        // User cancelled
-                        return;
-                    }
+                    // User cancelled
+                    return;
                 }
 
                 if(!CreateAllCheck.Checked)

--- a/emutool/emutool/MainForm.cs
+++ b/emutool/emutool/MainForm.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -234,11 +234,16 @@ namespace emutool
         {
             try
             {
-                string base_dir = SelectDirectory();
-                if(base_dir == null)
+                string base_dir = null;
+                if(!FtpSaveCheck.Checked)
                 {
-                    // User cancelled
-                    return;
+                    // If we're saving normally and we're not using the last path, ask the user for the path
+                    base_dir = SelectDirectory();
+                    if(base_dir == null)
+                    {
+                        // User cancelled
+                        return;
+                    }
                 }
 
                 if(!CreateAllCheck.Checked)
@@ -269,7 +274,7 @@ namespace emutool
                 }
                 else
                 {
-                    var actual_base_dir = base_dir;
+                    var actual_base_dir = "";
                     AmiiboSeries = Amiibos.GetAmiiboSeries();
                     if (AmiiboSeries.Any())
                     {


### PR DESCRIPTION
From #142

I don't have the tools installed to run C# and test this, but just looking at [MainForm.cs:283](https://github.com/XorTroll/emuiibo/blob/77ab09b21e64ab375179d71c196c70b6acbf6fb2/emutool/emutool/MainForm.cs#L283), `actual_base_dir` is currently null according to the error.

`actual_base_dir` is set to be the original `base_dir`, which is initialized as null and then never touched. I believe removing the [if statement](https://github.com/XorTroll/emuiibo/blob/77ab09b21e64ab375179d71c196c70b6acbf6fb2/emutool/emutool/MainForm.cs#L237) would fix this.