### PR TITLE
Fixing Amiibo name limit

### DIFF
--- a/emutool/emutool/MainForm.Designer.cs
+++ b/emutool/emutool/MainForm.Designer.cs
@@ -67,7 +67,7 @@
             // AmiiboNameBox
             // 
             this.AmiiboNameBox.Location = new System.Drawing.Point(124, 25);
-            this.AmiiboNameBox.MaxLength = 10;
+            this.AmiiboNameBox.MaxLength = 40;
             this.AmiiboNameBox.Name = "AmiiboNameBox";
             this.AmiiboNameBox.Size = new System.Drawing.Size(255, 20);
             this.AmiiboNameBox.TabIndex = 1;


### PR DESCRIPTION
The way EmuTool is right now you cant give an Amiibo an name that is longer than 10 character while the specification in the readme claims 10. And while I'm not familiar with the project a quick searching lead me to this line as the culprit. `this.AmiiboNameBox.MaxLength = 10;`
I believe this to be the sole cause and is just a mistake therefore I created this PR to iron out this small bug.